### PR TITLE
Add clickable links to TODO reports

### DIFF
--- a/plugins/hook-todo-collector/scripts/collect-todos.js
+++ b/plugins/hook-todo-collector/scripts/collect-todos.js
@@ -191,7 +191,9 @@ Total Items: ${todos.length}
     report += `## ${type} (${grouped[type].length})\n\n`;
 
     grouped[type].forEach(todo => {
-      report += `- **${todo.file}:${todo.line}**\n`;
+      // Convert backslashes to forward slashes for cross-platform compatibility
+      const fileLink = todo.file.replace(/\\/g, '/');
+      report += `- **[${todo.file}:${todo.line}](${fileLink}#L${todo.line})**\n`;
       report += `  \`${todo.message}\`\n\n`;
     });
   });
@@ -209,7 +211,9 @@ Total Items: ${todos.length}
   Object.entries(byFile)
     .sort((a, b) => b[1] - a[1])
     .forEach(([file, count]) => {
-      report += `- ${file}: ${count} item(s)\n`;
+      // Convert backslashes to forward slashes for cross-platform compatibility
+      const fileLink = file.replace(/\\/g, '/');
+      report += `- [${file}](${fileLink}): ${count} item(s)\n`;
     });
 
   return report;


### PR DESCRIPTION
- Convert TODO items to markdown links with line numbers
- Format: [file:line](file#Lline) for direct navigation
- Summary by File section also now clickable
- Cross-platform path compatibility (backslash to forward slash)
- Enable Ctrl+Click navigation in IDEs