### PR TITLE
fix: Code quality improvements for Spec-Kit commands

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "Productivity plugins for Claude Code to automate development workflows",
-    "version": "2.1.0",
+    "version": "2.2.0",
     "homepage": "https://github.com/Dev-GOM/claude-code-marketplace"
   },
   "plugins": [

--- a/plugins/spec-kit/commands/implement.md
+++ b/plugins/spec-kit/commands/implement.md
@@ -413,7 +413,8 @@ mkdir -p "specs/$CURRENT_BRANCH/drafts"
 Write 도구를 사용하여 수집된 정보를 **생성한 파일명**으로 저장합니다:
 
 ```
-파일 경로: specs/$CURRENT_BRANCH/drafts/task-[번호]-[slug]-draft.md
+파일 경로: specs/$CURRENT_BRANCH/drafts/[phase]-[task-id]-[slug]-draft.md
+예시: specs/$CURRENT_BRANCH/drafts/p2-t010-currency-draft.md
 ```
 
 ```markdown

--- a/plugins/spec-kit/commands/init.md
+++ b/plugins/spec-kit/commands/init.md
@@ -545,12 +545,12 @@ sudo apt install gh -y
 
 **Linux (Fedora):**
 ```bash
-sudo dnf install gh
+sudo dnf install gh -y
 ```
 
 **Linux (Arch):**
 ```bash
-sudo pacman -S github-cli
+sudo pacman -S github-cli --noconfirm
 ```
 
 설치 완료:


### PR DESCRIPTION
# Code Quality Improvements

## 🐛 Fixes

### 1. File Path Example Inconsistency (implement.md)
- **Issue**: Example showed `task-[번호]-[slug]-draft.md` instead of the documented format
- **Fix**: Updated to `[phase]-[task-id]-[slug]-draft.md`
- **Example**: Added `p2-t010-currency-draft.md` for clarity

### 2. Non-Interactive Package Installation (init.md)
- **dnf**: Added `-y` flag to `sudo dnf install gh`
- **pacman**: Added `--noconfirm` flag to `sudo pacman -S github-cli`
- **Benefit**: Prevents installation from hanging waiting for user confirmation

## 📦 Version Update
- Updated `marketplace.json` metadata.version to 2.2.0

## 🔗 Related
- Release: https://github.com/Dev-GOM/claude-code-marketplace/releases/tag/v2.2.0
- Previous PR: #19
- Commit: 236314d

## ✅ Checklist
- [x] Fixed file path example inconsistency
- [x] Added non-interactive flags for package managers
- [x] Updated marketplace metadata version
- [x] No breaking changes