### PR TITLE
Fix: Auto Release Manager plugin.json skills path

### DIFF
--- a/plugins/auto-release-manager/.claude-plugin/plugin.json
+++ b/plugins/auto-release-manager/.claude-plugin/plugin.json
@@ -25,6 +25,6 @@
     "cross-platform"
   ],
   "skills": [
-    "auto-release-manager"
+    "./skills"
   ]
 }


### PR DESCRIPTION
# Fix: plugin.json skills path

## Fixed
- Corrected skills array in plugin.json to use relative path `./skills` instead of skill name
- Fixes plugin loading validation error: `skills.0: Invalid input: must start with "./"`

## Changes
- `plugins/auto-release-manager/.claude-plugin/plugin.json`: Changed skills from `"auto-release-manager"` to `"./skills"`

---

**Commit**: b264e98