### PR TITLE
docs: Add language links to Auto Release Manager READMEs

### DIFF
--- a/plugins/auto-release-manager/README.ko.md
+++ b/plugins/auto-release-manager/README.ko.md
@@ -1,5 +1,7 @@
 # Auto Release Manager
 
+[English Documentation](README.md)
+
 > 지능형 감지 및 크로스 플랫폼 지원으로 모든 프로젝트 타입의 버전 업데이트 및 릴리즈를 자동화합니다.
 
 ## 개요

--- a/plugins/auto-release-manager/README.md
+++ b/plugins/auto-release-manager/README.md
@@ -1,5 +1,7 @@
 # Auto Release Manager
 
+[한국어 문서](README.ko.md)
+
 > Automate version updates and releases for any project type with intelligent detection and cross-platform support.
 
 ## Overview


### PR DESCRIPTION
# Documentation Enhancement

## Added
- Language navigation links to Auto Release Manager README files
  - `[한국어 문서](README.ko.md)` to README.md
  - `[English Documentation](README.md)` to README.ko.md

Now consistent with all other plugins in the marketplace.

---

**Commit**: 3a09156