### PR TITLE
fix: Browser Pilot SessionStart hook error

### DIFF
--- a/plugins/browser-pilot/scripts/init-config.js
+++ b/plugins/browser-pilot/scripts/init-config.js
@@ -17,7 +17,7 @@ const { createLogger } = require('./logger');
 const logger = createLogger('init-log.txt', 'Browser Pilot Initialization Log');
 
 /**
- * Get project root from environment variable or hook input
+ * Get project root from environment variable, hook input, or process.cwd()
  */
 function getProjectRoot(hookInput) {
   // Try environment variable first
@@ -29,11 +29,10 @@ function getProjectRoot(hookInput) {
     logger.log('Using cwd from hook input as project root');
   }
 
+  // Final fallback to process.cwd()
   if (!projectRoot) {
-    logger.error('Error: Could not determine project root');
-    logger.error('CLAUDE_PROJECT_DIR not set and no cwd in hook input');
-    logger.close();
-    process.exit(1);
+    projectRoot = process.cwd();
+    logger.log('Using process.cwd() as project root: ' + projectRoot);
   }
 
   return projectRoot;


### PR DESCRIPTION
## 문제 해결

### 발생한 에러
```
SessionStart:resume says: Plugin hook error: Error: Could not determine project root
CLAUDE_PROJECT_DIR not set and no cwd in hook input
```

### 원인
`init-config.js`의 `getProjectRoot()` 함수가:
- `process.env.CLAUDE_PROJECT_DIR` 없음
- `hookInput.cwd` 없음

위 두 조건이 모두 충족되지 않을 때 에러를 발생시킴.

특히 `resume` 이벤트에서 `hookInput.cwd`가 제공되지 않는 경우 발생.

### 해결책
`process.cwd()`를 최종 fallback으로 추가:

```javascript
function getProjectRoot(hookInput) {
  // 1. Try environment variable first
  let projectRoot = process.env.CLAUDE_PROJECT_DIR;

  // 2. Fallback to hook input cwd
  if (!projectRoot && hookInput && hookInput.cwd) {
    projectRoot = hookInput.cwd;
    logger.log('Using cwd from hook input as project root');
  }

  // 3. Final fallback to process.cwd() ← 신규 추가
  if (!projectRoot) {
    projectRoot = process.cwd();
    logger.log('Using process.cwd() as project root: ' + projectRoot);
  }

  return projectRoot;
}
```

### 장점
- ✅ 모든 세션 시작 시나리오에서 작동 (startup, resume, clear, compact)
- ✅ 에러 없이 정상 초기화 진행
- ✅ Claude Code의 작업 디렉토리를 프로젝트 루트로 사용

### 테스트
- [x] 정상 세션 시작 (startup)
- [x] 세션 재개 (resume) 
- [x] `hookInput.cwd` 없는 경우

### 변경된 파일
- `plugins/browser-pilot/scripts/init-config.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)