### PR TITLE
fix: Browser Pilot multi-project daemon conflicts

### DIFF
--- a/plugins/browser-pilot/scripts/init-config.js
+++ b/plugins/browser-pilot/scripts/init-config.js
@@ -251,8 +251,22 @@ function initializeLocalScripts(projectRoot) {
     fs.copyFileSync(path.join(pluginScriptsPath, 'package.json'), path.join(localSkillsPath, 'package.json'));
     fs.copyFileSync(path.join(pluginScriptsPath, 'tsconfig.json'), path.join(localSkillsPath, 'tsconfig.json'));
 
+    // Clean dist and node_modules for fresh install
+    const distPath = path.join(localSkillsPath, 'dist');
+    const nodeModulesPath = path.join(localSkillsPath, 'node_modules');
+
+    if (fs.existsSync(distPath)) {
+      logger.log('Removing old dist folder...');
+      fs.rmSync(distPath, { recursive: true, force: true });
+    }
+
+    if (fs.existsSync(nodeModulesPath)) {
+      logger.log('Removing old node_modules folder...');
+      fs.rmSync(nodeModulesPath, { recursive: true, force: true });
+    }
+
     // Install dependencies and build
-    logger.log('Installing dependencies...');
+    logger.log('Installing dependencies (clean install)...');
     execSync('npm install', { cwd: localSkillsPath, stdio: 'inherit' });
 
     logger.log('Building scripts...');

--- a/plugins/browser-pilot/skills/scripts/package.json
+++ b/plugins/browser-pilot/skills/scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browser-pilot-cli",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Chrome DevTools Protocol browser automation CLI",
   "main": "dist/cli/cli.js",
   "bin": {

--- a/plugins/browser-pilot/skills/scripts/src/daemon/client.ts
+++ b/plugins/browser-pilot/skills/scripts/src/daemon/client.ts
@@ -14,7 +14,8 @@ import {
   IPCError,
   IPCErrorCodes,
   SOCKET_PATH_PREFIX,
-  DEFAULT_TIMEOUT
+  DEFAULT_TIMEOUT,
+  getProjectSocketName
 } from './protocol';
 import { logger } from '../utils/logger';
 
@@ -34,16 +35,15 @@ export class IPCClient {
   }
 
   /**
-   * Get socket path (platform-specific)
+   * Get socket path (platform-specific, project-unique)
    */
   private getSocketPath(outputDir: string): string {
     if (process.platform === 'win32') {
-      // Windows: need to find the named pipe from PID
-      // For now, we'll use a fixed name pattern
-      // In production, we should read the PID file and construct the pipe name
-      return `\\\\.\\pipe\\${SOCKET_PATH_PREFIX}`;
+      // Windows: project-specific named pipe
+      const socketName = getProjectSocketName();
+      return `\\\\.\\pipe\\${socketName}`;
     } else {
-      // Unix domain socket
+      // Unix domain socket (already project-specific via outputDir)
       return join(outputDir, `${SOCKET_PATH_PREFIX}.sock`);
     }
   }

--- a/plugins/browser-pilot/skills/scripts/src/daemon/manager.ts
+++ b/plugins/browser-pilot/skills/scripts/src/daemon/manager.ts
@@ -16,7 +16,8 @@ import {
   MapQueryResult,
   MapGenerateParams,
   MapGenerateResult,
-  MapStatusResult
+  MapStatusResult,
+  getProjectSocketName
 } from './protocol';
 import { logger } from '../utils/logger';
 import { TIMING, DAEMON } from '../constants';
@@ -33,12 +34,15 @@ export class DaemonManager {
   }
 
   /**
-   * Get socket path (platform-specific)
+   * Get socket path (platform-specific, project-unique)
    */
   private getSocketPath(): string {
     if (process.platform === 'win32') {
-      return `\\\\.\\pipe\\${SOCKET_PATH_PREFIX}`;
+      // Windows: project-specific named pipe
+      const socketName = getProjectSocketName();
+      return `\\\\.\\pipe\\${socketName}`;
     } else {
+      // Unix domain socket (already project-specific via outputDir)
       return join(this.outputDir, `${SOCKET_PATH_PREFIX}.sock`);
     }
   }

--- a/plugins/browser-pilot/skills/scripts/src/daemon/protocol.ts
+++ b/plugins/browser-pilot/skills/scripts/src/daemon/protocol.ts
@@ -176,6 +176,22 @@ export const DEFAULT_TIMEOUT = 30000; // 30 seconds
 export const IDLE_SHUTDOWN_TIMEOUT = 1800000; // 30 minutes
 
 /**
+ * Get project-specific socket name
+ * Uses project folder name to create unique socket for each project
+ */
+export function getProjectSocketName(): string {
+  const { basename } = require('path');
+  const { findProjectRoot } = require('../cdp/config');
+
+  const projectRoot = findProjectRoot();
+  const projectName = basename(projectRoot)
+    .replace(/[^a-zA-Z0-9_-]/g, '-')  // Replace special chars with hyphen
+    .toLowerCase();
+
+  return `${SOCKET_PATH_PREFIX}-${projectName}`;
+}
+
+/**
  * Protocol errors
  */
 

--- a/plugins/browser-pilot/skills/scripts/src/daemon/server.ts
+++ b/plugins/browser-pilot/skills/scripts/src/daemon/server.ts
@@ -17,7 +17,8 @@ import {
   IPCErrorCodes,
   SOCKET_PATH_PREFIX,
   PID_FILENAME,
-  IDLE_SHUTDOWN_TIMEOUT
+  IDLE_SHUTDOWN_TIMEOUT,
+  getProjectSocketName
 } from './protocol';
 import { MapManager } from './map-manager';
 import { logger } from '../utils/logger';
@@ -46,14 +47,15 @@ export class DaemonServer {
   }
 
   /**
-   * Get socket path (platform-specific)
+   * Get socket path (platform-specific, project-unique)
    */
   private getSocketPath(): string {
     if (process.platform === 'win32') {
-      // Windows named pipe (no PID - must match client)
-      return `\\\\.\\pipe\\${SOCKET_PATH_PREFIX}`;
+      // Windows: project-specific named pipe
+      const socketName = getProjectSocketName();
+      return `\\\\.\\pipe\\${socketName}`;
     } else {
-      // Unix domain socket
+      // Unix domain socket (already project-specific via outputDir)
       return join(this.outputDir, `${SOCKET_PATH_PREFIX}.sock`);
     }
   }


### PR DESCRIPTION
## 문제 해결

### 1. 다중 프로젝트 데몬 충돌

**발생한 에러:**
```
Error: listen EADDRINUSE: address already in use \.\pipe\daemon
```

**원인:**
- Windows에서 IPC 파이프 이름이 고정: `\.\pipe\daemon`
- 모든 프로젝트가 동일한 파이프 사용 → 충돌 발생
- Unix는 이미 프로젝트별 분리됨: `<project>/.browser-pilot/daemon.sock`

**해결책:**
프로젝트 이름 기반 고유 파이프 이름:
- Windows: `\.\pipe\daemon-<project-name>`
- Unix: 변경 없음 (이미 올바름)

**예시:**
```
\.\pipe\daemon-claude-code-marketplace
\.\pipe\daemon-korzom
\.\pipe\daemon-ai-trade-bot
```

### 2. 플러그인 업데이트 프로세스 개선

**개선사항:**
업데이트 전 `dist/`와 `node_modules/` 삭제로 캐시 문제 방지

**업데이트 순서:**
1. 기존 스크립트 백업
2. 소스 파일 복사
3. **dist 폴더 삭제** ← 신규
4. **node_modules 폴더 삭제** ← 신규
5. npm install (clean)
6. npm run build
7. 성공 시 백업 삭제

## 변경된 파일

### Daemon IPC (프로젝트별 분리)
- `src/daemon/protocol.ts`: `getProjectSocketName()` 함수 추가
- `src/daemon/server.ts`: Windows 파이프 이름을 프로젝트별로 생성
- `src/daemon/client.ts`: 클라이언트도 동일한 로직 적용
- `src/daemon/manager.ts`: 매니저도 동일한 로직 적용

### 업데이트 프로세스
- `scripts/init-config.js`: dist/node_modules 삭제 로직 추가

### 버전
- `package.json`: 1.4.0 → 1.4.1

## 테스트

- [x] 두 개의 다른 프로젝트에서 동시 데몬 실행
- [x] 각 프로젝트가 독립적인 파이프 사용
- [x] Windows 환경에서 정상 작동 확인
- [x] Clean install로 빌드 성공

## 장점

✅ **다중 프로젝트 지원**: 여러 프로젝트에서 동시에 Browser Pilot 사용 가능  
✅ **크로스 플랫폼**: Windows와 Unix 모두 올바르게 작동  
✅ **Clean 업데이트**: 캐시 문제 없이 깔끔한 업데이트

## 이전 커밋

이 PR은 다음 커밋들을 포함합니다:
- `6bd79a5`: fix(browser-pilot): Add process.cwd() fallback in init-config.js
- `6c46fa6`: docs(browser-pilot): Update README to reflect v1.4.0 features
- `6a47ed2`: feat: Browser Pilot v1.4.0 & Apache 2.0 License Migration
- `ead63ad`: fix(browser-pilot): Resolve multi-project daemon conflicts & improve update process

🤖 Generated with [Claude Code](https://claude.com/claude-code)