### PR TITLE
fix(browser-pilot): Fix findProjectRoot import path

### DIFF
--- a/plugins/browser-pilot/skills/scripts/src/daemon/protocol.ts
+++ b/plugins/browser-pilot/skills/scripts/src/daemon/protocol.ts
@@ -181,7 +181,7 @@ export const IDLE_SHUTDOWN_TIMEOUT = 1800000; // 30 minutes
  */
 export function getProjectSocketName(): string {
   const { basename } = require('path');
-  const { findProjectRoot } = require('../cdp/config');
+  const { findProjectRoot } = require('../cdp/utils');
 
   const projectRoot = findProjectRoot();
   const projectName = basename(projectRoot)


### PR DESCRIPTION
Fixes 'findProjectRoot is not a function' error by correcting import path from '../cdp/config' to '../cdp/utils'