### PR TITLE
fix(browser-pilot): Set CLAUDE_PROJECT_DIR in wrapper script

### DIFF
--- a/plugins/browser-pilot/scripts/init-config.js
+++ b/plugins/browser-pilot/scripts/init-config.js
@@ -175,6 +175,9 @@ function createWrapperScript(projectRoot) {
 
 const path = require('path');
 
+// Set CLAUDE_PROJECT_DIR to project root (parent of .browser-pilot)
+process.env.CLAUDE_PROJECT_DIR = path.resolve(__dirname, '..');
+
 // Get the actual CLI path
 const cliPath = path.join(__dirname, 'skills', 'scripts', 'dist', 'cli', 'cli.js');
 


### PR DESCRIPTION
Fixes 'Could not determine project root' error