### PR TITLE
fix(browser-pilot): Replace npm ci with npm install

### DIFF
--- a/plugins/browser-pilot/scripts/init-config.js
+++ b/plugins/browser-pilot/scripts/init-config.js
@@ -357,8 +357,8 @@ async function initializeLocalScripts(projectRoot) {
   }
 
   // Install dependencies and build
-  logger.log('Installing dependencies (clean install)...');
-  execSync('npm ci', { cwd: localSkillsPath, stdio: 'inherit' });
+  logger.log('Installing dependencies...');
+  execSync('npm install', { cwd: localSkillsPath, stdio: 'inherit' });
 
   logger.log('Building scripts...');
   execSync('npm run build', { cwd: localSkillsPath, stdio: 'inherit' });


### PR DESCRIPTION
## Bug Fix

### Issue
SessionStart 훅에서 npm ci 실패:
- package.json과 package-lock.json 버전 불일치 시 실패
- lockfileVersion 문제로 초기화 중단

### Solution
`npm ci` → `npm install`로 변경

### Why npm install?
- package-lock.json 버전 불일치 시 자동 업데이트
- 더 관대한 의존성 해결
- 개발 환경에서 더 안정적

### Impact
- SessionStart 초기화 성공률 향상
- 플러그인 업데이트 프로세스 안정화

🤖 Generated with [Claude Code](https://claude.com/claude-code)