### PR TITLE
debug(browser-pilot): Add delete failure diagnostics

### DIFF
--- a/plugins/browser-pilot/scripts/init-config.js
+++ b/plugins/browser-pilot/scripts/init-config.js
@@ -332,7 +332,30 @@ async function initializeLocalScripts(projectRoot) {
         lastDeleteError = error;
         logger.log('Delete attempt ' + attempt + ' failed: ' + error.message);
 
-        if (attempt < maxDeleteRetries) {
+        // Log remaining files for debugging
+        if (attempt < maxDeleteRetries && fs.existsSync(skillsDir)) {
+          try {
+            const remainingFiles = [];
+            const scanDir = (dir) => {
+              const items = fs.readdirSync(dir);
+              items.forEach(item => {
+                const fullPath = path.join(dir, item);
+                const stat = fs.statSync(fullPath);
+                if (stat.isDirectory()) {
+                  scanDir(fullPath);
+                } else {
+                  remainingFiles.push(fullPath.replace(skillsDir + path.sep, ''));
+                }
+              });
+            };
+            scanDir(skillsDir);
+            if (remainingFiles.length > 0) {
+              logger.log('Remaining files (' + remainingFiles.length + '): ' + remainingFiles.slice(0, 5).join(', ') + (remainingFiles.length > 5 ? ' ...' : ''));
+            }
+          } catch (scanError) {
+            // Ignore scan errors
+          }
+
           logger.log('Waiting 2 seconds before retry...');
           await sleep(2000);
         }


### PR DESCRIPTION
## Changes

### 삭제 실패 디버깅 개선

**추가 기능:**
- 폴더 삭제 실패 시 남아있는 파일 목록 로깅
- 최대 5개 파일 이름 표시
- init-log.txt에서 어떤 파일이 잠겨있는지 확인 가능

**목적:**
- STEP 1 삭제 실패 원인 파악
- package-lock.json 또는 dist/*.js 파일 잠김 여부 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>