### PR TITLE
fix(browser-pilot): Improve SessionStart update process reliability

### DIFF
--- a/plugins/browser-pilot/scripts/init-config.js
+++ b/plugins/browser-pilot/scripts/init-config.js
@@ -10,7 +10,7 @@
 
 const fs = require('fs');
 const path = require('path');
-const { execSync } = require('child_process');
+const { execSync, spawn } = require('child_process');
 const { createLogger } = require('./logger');
 const processUtils = require('./process-utils');
 
@@ -322,11 +322,35 @@ async function initializeLocalScripts(projectRoot) {
     if (fs.existsSync(scriptsPath)) {
       try {
         logger.log('[STEP 1] Pre-cleanup: Removing dist and node_modules...');
-        // Use npx rimraf for cross-platform deletion (npm 5.2+)
-        execSync('npx rimraf dist node_modules', {
-          cwd: scriptsPath,
-          stdio: 'ignore'
+
+        // Run npx rimraf as separate process and wait for completion
+        await new Promise((resolve, reject) => {
+          const rimraf = spawn('npx', ['rimraf', 'dist', 'node_modules'], {
+            cwd: scriptsPath,
+            stdio: 'ignore'
+          });
+
+          rimraf.on('close', (code) => {
+            if (code === 0) {
+              resolve();
+            } else {
+              reject(new Error(`rimraf exited with code ${code}`));
+            }
+          });
+
+          rimraf.on('error', (error) => {
+            reject(error);
+          });
         });
+
+        // Verify deletion after process has completed
+        const distDir = path.join(scriptsPath, 'dist');
+        const nodeModulesDir = path.join(scriptsPath, 'node_modules');
+
+        if (fs.existsSync(distDir) || fs.existsSync(nodeModulesDir)) {
+          throw new Error('Folders still exist after rimraf completion');
+        }
+
         logger.log('✓ dist and node_modules removed');
       } catch (error) {
         logger.log('Failed to remove dist/node_modules: ' + error.message);


### PR DESCRIPTION
## Summary

Browser Pilot의 SessionStart 훅 업데이트 프로세스 안정성 개선:
- execSync 대신 spawn으로 rimraf 실행하여 프로세스 완전 종료 보장
- 파일 시스템 flush 문제로 인한 폴더 삭제 실패 해결
- package-lock.json git 추적 제거

## Changes

1. **spawn 기반 rimraf 실행** (3c02c25)
   - execSync → spawn으로 변경
   - close 이벤트로 프로세스 종료 대기
   - 종료 후 폴더 삭제 확인으로 안정성 향상

2. **npx rimraf 도입** (a1a35de)
   - 크로스 플랫폼 폴더 삭제 개선
   - fs.rmSync fallback 유지

3. **Pre-cleanup 단계 추가** (acdb34e)
   - dist와 node_modules를 먼저 삭제
   - 파일 잠금 문제 완화

4. **디버깅 로깅 개선** (8728f60)
   - 남은 파일 수 로깅 추가

5. **package-lock.json 추적 제거** (b94d9aa)
   - npm install이 자동 생성하므로 git에서 제거
   - .gitignore에 이미 포함됨

## Test Plan

- [x] 세션 재시작 시 자동 업데이트 성공
- [x] dist와 node_modules 삭제 확인
- [x] rimraf 프로세스 완료 후 폴더 확인
- [x] 폴더 삭제 실패 시 fallback 동작

🤖 Generated with [Claude Code](https://claude.com/claude-code)