### PR TITLE
fix(browser-pilot): Add lock mechanism to prevent concurrent initialization

### DIFF
--- a/plugins/browser-pilot/scripts/init-config.js
+++ b/plugins/browser-pilot/scripts/init-config.js
@@ -610,8 +610,67 @@ async function readHookInput() {
   });
 }
 
+/**
+ * Acquire lock file to prevent concurrent execution
+ */
+async function acquireLock(projectRoot) {
+  const lockFile = path.join(projectRoot, '.browser-pilot', '.init.lock');
+  const maxWait = 30000; // 30 seconds
+  const checkInterval = 500; // 500ms
+  const startTime = Date.now();
+
+  while (fs.existsSync(lockFile)) {
+    // Check if lock file is stale (older than 5 minutes)
+    try {
+      const stats = fs.statSync(lockFile);
+      const age = Date.now() - stats.mtimeMs;
+      if (age > 300000) {
+        logger.log('Removing stale lock file (age: ' + Math.floor(age / 1000) + 's)');
+        fs.unlinkSync(lockFile);
+        break;
+      }
+    } catch (error) {
+      // Lock file deleted by other process
+      break;
+    }
+
+    if (Date.now() - startTime > maxWait) {
+      throw new Error('Timeout waiting for lock file. Another initialization may be in progress.');
+    }
+
+    logger.log('Waiting for another init process to complete...');
+    await sleep(checkInterval);
+  }
+
+  // Create lock file
+  const lockDir = path.dirname(lockFile);
+  if (!fs.existsSync(lockDir)) {
+    fs.mkdirSync(lockDir, { recursive: true });
+  }
+  fs.writeFileSync(lockFile, String(process.pid));
+  logger.log('Lock acquired (PID: ' + process.pid + ')');
+
+  return lockFile;
+}
+
+/**
+ * Release lock file
+ */
+function releaseLock(lockFile) {
+  try {
+    if (fs.existsSync(lockFile)) {
+      fs.unlinkSync(lockFile);
+      logger.log('Lock released');
+    }
+  } catch (error) {
+    logger.log('Failed to release lock: ' + error.message);
+  }
+}
+
 // Main execution
 (async () => {
+  let lockFile = null;
+
   try {
     // Read hook input to check source
     const hookInput = await readHookInput();
@@ -627,15 +686,23 @@ async function readHookInput() {
       process.exit(0);
     }
 
+    // Get project root for lock file
+    const projectRoot = getProjectRoot(hookInput);
+
+    // Acquire lock before running initialization
+    lockFile = await acquireLock(projectRoot);
+
     // Run initialization on startup, resume, or unknown
     await initializeProject(hookInput);
 
     logger.close();
+    releaseLock(lockFile);
     process.exit(0);
   } catch (error) {
     logger.error('Error initializing Browser Pilot: ' + error.message);
     logger.error('Stack: ' + error.stack);
     logger.close();
+    if (lockFile) releaseLock(lockFile);
     process.exit(1);
   }
 })();


### PR DESCRIPTION
## Summary

SessionStart 훅 중복 트리거 시 발생하는 동시 실행 문제 해결:
- 락 파일 메커니즘으로 순차 실행 보장
- 리소스 경쟁(ENOTEMPTY) 방지
- Stale 락 파일 자동 정리

## Problem

SessionStart 훅이 동시에 여러 번 트리거되면:
1. 두 개 이상의 init-config.js가 동시 실행
2. 같은 폴더 삭제/복사 시도로 ENOTEMPTY 에러
3. 첫 번째 빌드 실패, 두 번째 빌드 성공 (비효율)

## Solution

**Lock 메커니즘 추가:**
```javascript
// 1. 락 파일 획득 (다른 프로세스 실행 중이면 대기)
lockFile = await acquireLock(projectRoot);

// 2. 초기화 작업 수행
await initializeProject(hookInput);

// 3. 완료 후 락 해제
releaseLock(lockFile);
```

**주요 기능:**
- `.browser-pilot/.init.lock` 파일로 동시 실행 방지
- 최대 30초 대기 (500ms 간격 폴링)
- 5분 이상 된 stale 락 파일 자동 삭제
- PID 기록으로 디버깅 용이
- 성공/실패 모두 락 해제 보장

## Changes

1. **acquireLock() 함수** (727545c)
   - 락 파일 확인 및 대기
   - Stale 락 파일 정리
   - 락 파일 생성 및 PID 기록

2. **releaseLock() 함수**
   - 작업 완료 후 락 파일 삭제
   - 에러 발생 시에도 락 해제

3. **메인 실행 로직 수정**
   - 초기화 전 락 획득
   - try-finally로 락 해제 보장

## Test Plan

- [x] 동시 실행 시 순차 처리 확인
- [x] 첫 번째 프로세스 완료 후 두 번째 실행
- [x] Stale 락 파일 자동 정리 테스트
- [x] 에러 발생 시 락 해제 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)