### PR TITLE
fix(browser-pilot): Add missing sleep function

### DIFF
--- a/plugins/browser-pilot/scripts/init-config.js
+++ b/plugins/browser-pilot/scripts/init-config.js
@@ -49,6 +49,13 @@ function getProjectName(projectRoot) {
 }
 
 /**
+ * Sleep utility for async delays
+ */
+function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+/**
  * Get shared config file path
  */
 function getSharedConfigPath() {


### PR DESCRIPTION
## Summary

acquireLock()에서 사용하는 sleep 함수 누락으로 발생하는 ReferenceError 수정

## Problem

```
ReferenceError: sleep is not defined
    at acquireLock
```

락 메커니즘 추가 시 sleep 함수를 사용했지만 정의하지 않아 SessionStart 훅 실행 시 에러 발생

## Solution

Promise 기반 sleep 함수 추가:

```javascript
function sleep(ms) {
  return new Promise(resolve => setTimeout(resolve, ms));
}
```

## Changes

- sleep() 함수 정의 추가
- acquireLock()의 폴링 로직에서 사용

## Test

- [x] Lint 통과
- [x] Type check 통과
- [x] Build 성공

🤖 Generated with [Claude Code](https://claude.com/claude-code)