### PR TITLE
fix: TypeScript 빌드 에러 수정

### DIFF
--- a/plugins/blender-toolkit/skills/blender-retargeting/scripts/src/cli/commands/geometry.ts
+++ b/plugins/blender-toolkit/skills/blender-retargeting/scripts/src/cli/commands/geometry.ts
@@ -24,7 +24,7 @@ export function registerGeometryCommands(program: Command) {
       try {
         await client.connect(options.port);
 
-        const result = await client.sendCommand('Geometry.createCube', {
+        const result: any = await client.sendCommand('Geometry.createCube', {
           location: [options.x, options.y, options.z],
           size: options.size,
           name: options.name
@@ -60,7 +60,7 @@ export function registerGeometryCommands(program: Command) {
       try {
         await client.connect(options.port);
 
-        const result = await client.sendCommand('Geometry.createSphere', {
+        const result: any = await client.sendCommand('Geometry.createSphere', {
           location: [options.x, options.y, options.z],
           radius: options.radius,
           segments: options.segments,
@@ -98,7 +98,7 @@ export function registerGeometryCommands(program: Command) {
       try {
         await client.connect(options.port);
 
-        const result = await client.sendCommand('Geometry.createCylinder', {
+        const result: any = await client.sendCommand('Geometry.createCylinder', {
           location: [options.x, options.y, options.z],
           radius: options.radius,
           depth: options.depth,
@@ -134,7 +134,7 @@ export function registerGeometryCommands(program: Command) {
       try {
         await client.connect(options.port);
 
-        const result = await client.sendCommand('Geometry.createPlane', {
+        const result: any = await client.sendCommand('Geometry.createPlane', {
           location: [options.x, options.y, options.z],
           size: options.size,
           name: options.name
@@ -170,7 +170,7 @@ export function registerGeometryCommands(program: Command) {
       try {
         await client.connect(options.port);
 
-        const result = await client.sendCommand('Geometry.createCone', {
+        const result: any = await client.sendCommand('Geometry.createCone', {
           location: [options.x, options.y, options.z],
           radius1: options.radius,
           depth: options.depth,
@@ -209,7 +209,7 @@ export function registerGeometryCommands(program: Command) {
       try {
         await client.connect(options.port);
 
-        const result = await client.sendCommand('Geometry.createTorus', {
+        const result: any = await client.sendCommand('Geometry.createTorus', {
           location: [options.x, options.y, options.z],
           majorRadius: options.majorRadius,
           minorRadius: options.minorRadius,
@@ -243,7 +243,7 @@ export function registerGeometryCommands(program: Command) {
       try {
         await client.connect(options.port);
 
-        const result = await client.sendCommand('Geometry.subdivideMesh', {
+        const result: any = await client.sendCommand('Geometry.subdivideMesh', {
           name: options.name,
           cuts: options.cuts
         });
@@ -272,7 +272,7 @@ export function registerGeometryCommands(program: Command) {
       try {
         await client.connect(options.port);
 
-        const vertices = await client.sendCommand('Geometry.getVertices', {
+        const vertices: any = await client.sendCommand('Geometry.getVertices', {
           name: options.name
         });
 
@@ -318,7 +318,7 @@ export function registerGeometryCommands(program: Command) {
       try {
         await client.connect(options.port);
 
-        const result = await client.sendCommand('Geometry.moveVertex', {
+        const result: any = await client.sendCommand('Geometry.moveVertex', {
           objectName: options.name,
           vertexIndex: options.index,
           newPosition: [options.x, options.y, options.z]

--- a/plugins/blender-toolkit/skills/blender-retargeting/scripts/src/cli/commands/modifier.ts
+++ b/plugins/blender-toolkit/skills/blender-retargeting/scripts/src/cli/commands/modifier.ts
@@ -34,7 +34,7 @@ export function registerModifierCommands(program: Command) {
           properties.render_levels = options.renderLevels;
         }
 
-        const result = await client.sendCommand('Modifier.add', {
+        const result: any = await client.sendCommand('Modifier.add', {
           objectName: options.name,
           modifierType: options.type,
           name: options.modName,
@@ -64,7 +64,7 @@ export function registerModifierCommands(program: Command) {
       try {
         await client.connect(options.port);
 
-        const result = await client.sendCommand('Modifier.apply', {
+        const result: any = await client.sendCommand('Modifier.apply', {
           objectName: options.name,
           modifierName: options.modifier
         });
@@ -89,7 +89,7 @@ export function registerModifierCommands(program: Command) {
       try {
         await client.connect(options.port);
 
-        const result = await client.sendCommand('Modifier.list', {
+        const result: any = await client.sendCommand('Modifier.list', {
           objectName: options.name
         });
 
@@ -125,7 +125,7 @@ export function registerModifierCommands(program: Command) {
       try {
         await client.connect(options.port);
 
-        const result = await client.sendCommand('Modifier.remove', {
+        const result: any = await client.sendCommand('Modifier.remove', {
           objectName: options.name,
           modifierName: options.modifier
         });
@@ -165,7 +165,7 @@ export function registerModifierCommands(program: Command) {
           params.render = options.render === 'true';
         }
 
-        const result = await client.sendCommand('Modifier.toggle', params);
+        const result: any = await client.sendCommand('Modifier.toggle', params);
 
         console.log('✅ Modifier toggled:');
         console.log(`   Viewport: ${result.show_viewport}`);
@@ -203,7 +203,7 @@ export function registerModifierCommands(program: Command) {
         if (options.segments !== undefined) properties.segments = options.segments;
         if (options.count !== undefined) properties.count = options.count;
 
-        const result = await client.sendCommand('Modifier.modify', {
+        const result: any = await client.sendCommand('Modifier.modify', {
           objectName: options.name,
           modifierName: options.modifier,
           properties
@@ -231,7 +231,7 @@ export function registerModifierCommands(program: Command) {
       try {
         await client.connect(options.port);
 
-        const result = await client.sendCommand('Modifier.getInfo', {
+        const result: any = await client.sendCommand('Modifier.getInfo', {
           objectName: options.name,
           modifierName: options.modifier
         });
@@ -259,7 +259,7 @@ export function registerModifierCommands(program: Command) {
       try {
         await client.connect(options.port);
 
-        const result = await client.sendCommand('Modifier.reorder', {
+        const result: any = await client.sendCommand('Modifier.reorder', {
           objectName: options.name,
           modifierName: options.modifier,
           direction: options.direction.toUpperCase()

--- a/plugins/blender-toolkit/skills/blender-retargeting/scripts/src/cli/commands/object.ts
+++ b/plugins/blender-toolkit/skills/blender-retargeting/scripts/src/cli/commands/object.ts
@@ -20,7 +20,7 @@ export function registerObjectCommands(program: Command) {
       try {
         await client.connect(options.port);
 
-        const objects = await client.sendCommand('Object.list', {
+        const objects: any = await client.sendCommand('Object.list', {
           type: options.type
         });
 
@@ -91,7 +91,7 @@ export function registerObjectCommands(program: Command) {
           ];
         }
 
-        const result = await client.sendCommand('Object.transform', params);
+        const result: any = await client.sendCommand('Object.transform', params);
 
         console.log('✅ Object transformed successfully:');
         console.log(`   Name: ${result.name}`);
@@ -135,7 +135,7 @@ export function registerObjectCommands(program: Command) {
           ];
         }
 
-        const result = await client.sendCommand('Object.duplicate', params);
+        const result: any = await client.sendCommand('Object.duplicate', params);
 
         console.log('✅ Object duplicated successfully:');
         console.log(`   New Name: ${result.name}`);
@@ -160,7 +160,7 @@ export function registerObjectCommands(program: Command) {
       try {
         await client.connect(options.port);
 
-        const result = await client.sendCommand('Object.delete', {
+        const result: any = await client.sendCommand('Object.delete', {
           name: options.name
         });
 

--- a/plugins/blender-toolkit/skills/blender-retargeting/scripts/src/cli/commands/retargeting.ts
+++ b/plugins/blender-toolkit/skills/blender-retargeting/scripts/src/cli/commands/retargeting.ts
@@ -59,7 +59,7 @@ export function registerRetargetingCommands(program: Command) {
         const popularAnimations = workflow.getPopularAnimations();
         Object.entries(popularAnimations).forEach(([category, animations]) => {
           console.log(`\n${category}:`);
-          (animations as string[]).forEach((anim) => {
+          (animations as unknown as string[]).forEach((anim) => {
             console.log(`  • ${anim}`);
           });
         });


### PR DESCRIPTION
CLI 명령 타입 추론 문제 해결:
- sendCommand 결과에 명시적 타입 지정 (: any)
- geometry.ts, modifier.ts, object.ts에 적용
- retargeting.ts 타입 단언 수정 (as unknown as string[])

빌드 결과: 26개 에러 → 0개 에러
CLI 실행 가능 확인 완료