### PR TITLE
Unity Editor Toolkit - Fix Port Mismatch (9500-9600)

### DIFF
--- a/plugins/unity-editor-toolkit/hooks/hooks.json
+++ b/plugins/unity-editor-toolkit/hooks/hooks.json
@@ -13,7 +13,7 @@
           {
             "type": "command",
             "command": "node ${CLAUDE_PLUGIN_ROOT}/scripts/init-config.js",
-            "description": "Registers Unity project and assigns WebSocket port (9300-9400)",
+            "description": "Registers Unity project and assigns WebSocket port (9500-9600)",
             "continueOnError": true,
             "suppressOutput": false
           }

--- a/plugins/unity-editor-toolkit/skills/assets/unity-package/CHANGELOG.md
+++ b/plugins/unity-editor-toolkit/skills/assets/unity-package/CHANGELOG.md
@@ -25,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `UnityEditorServer` MonoBehaviour component
 - Editor window for server control (`Window → Unity Editor Toolkit → Server Control`)
 - Automatic console log capture
-- Configurable port (default: 9300)
+- Configurable port (default: 9500)
 - Auto-start option
 
 #### Security

--- a/plugins/unity-editor-toolkit/skills/assets/unity-package/ThirdParty/websocket-sharp/README.md
+++ b/plugins/unity-editor-toolkit/skills/assets/unity-package/ThirdParty/websocket-sharp/README.md
@@ -66,7 +66,7 @@ After adding the DLL, Unity should not show any import errors. Check Console (Ct
 
 1. Create GameObject → Add `UnityEditorServer` component
 2. Enter Play Mode
-3. Console should show: `✓ Unity Editor Server started on ws://127.0.0.1:9300`
+3. Console should show: `✓ Unity Editor Server started on ws://127.0.0.1:9500`
 
 ## Troubleshooting
 

--- a/plugins/unity-editor-toolkit/skills/scripts/src/constants/index.ts
+++ b/plugins/unity-editor-toolkit/skills/scripts/src/constants/index.ts
@@ -9,9 +9,9 @@
  * Unity WebSocket connection settings
  */
 export const UNITY = {
-  // Port range for Unity WebSocket servers (9300-9400)
-  DEFAULT_PORT: 9300,
-  MAX_PORT: 9400,
+  // Port range for Unity WebSocket servers (9500-9600)
+  DEFAULT_PORT: 9500,
+  MAX_PORT: 9600,
   LOCALHOST: '127.0.0.1',
 
   // WebSocket connection timeouts


### PR DESCRIPTION
## Summary

Unity Editor Toolkit 포트 불일치 수정 - CLI와 Unity 서버 포트를 9500-9600으로 통일

## Problem

CLI와 Unity 서버 간 포트 불일치로 연결 실패:
- **Unity C# 서버**: 9500 기본 포트 (UnityEditorServer.cs)
- **CLI 상수**: 9300-9400 사용 (잘못됨)
- **README 문서**: 9500-9600 명시 (맞음)

## Changes

### 1. CLI Constants (constants/index.ts)
```diff
- DEFAULT_PORT: 9300,
- MAX_PORT: 9400,
+ DEFAULT_PORT: 9500,
+ MAX_PORT: 9600,
```

### 2. Hooks Description (hooks/hooks.json)
```diff
- "description": "Registers Unity project and assigns WebSocket port (9300-9400)"
+ "description": "Registers Unity project and assigns WebSocket port (9500-9600)"
```

### 3. Unity Package CHANGELOG (CHANGELOG.md)
```diff
- Configurable port (default: 9300)
+ Configurable port (default: 9500)
```

### 4. websocket-sharp README (README.md)
```diff
- Console should show: `✓ Unity Editor Server started on ws://127.0.0.1:9300`
+ Console should show: `✓ Unity Editor Server started on ws://127.0.0.1:9500`
```

## Modified Files

```
plugins/unity-editor-toolkit/hooks/hooks.json
plugins/unity-editor-toolkit/skills/assets/unity-package/CHANGELOG.md
plugins/unity-editor-toolkit/skills/assets/unity-package/ThirdParty/websocket-sharp/README.md
plugins/unity-editor-toolkit/skills/scripts/src/constants/index.ts
```

## Testing

- [x] CLI 상수를 9500-9600으로 변경
- [x] 모든 문서의 포트 참조 업데이트
- [x] Unity 서버 기본 포트(9500)와 일치 확인

## Impact

- ✅ CLI와 Unity 서버 포트 일치 → 연결 성공
- ✅ 문서와 코드 일관성 확보
- ✅ 포트 불일치로 인한 연결 실패 해결
- ⚠️ 기존 사용자는 설정 파일 재생성 필요 (다음 세션 시 자동)
- 버전 변경 없음 (v0.3.1 유지)

🤖 Generated with [Claude Code](https://claude.com/claude-code)