### PR TITLE
Fix plugin installation instructions

### DIFF
--- a/plugins/blender-toolkit/README.md
+++ b/plugins/blender-toolkit/README.md
@@ -53,17 +53,31 @@ Blender automation toolkit for Claude Code - WebSocket-based real-time Blender c
 
 ## 📦 Installation
 
+### Install Plugin
+
+```bash
+# Add marketplace
+/plugin marketplace add https://github.com/Dev-GOM/claude-code-marketplace.git
+
+# Install plugin
+/plugin install blender-toolkit@dev-gom-plugins
+```
+
+**Or install directly**:
+```bash
+/plugin add https://github.com/Dev-GOM/claude-code-marketplace/tree/main/plugins/blender-toolkit
+```
+
 ### Automatic Setup (Recommended)
 
 Blender Toolkit uses SessionStart hooks to automatically initialize your project:
 
-1. **Install Plugin** via Claude Code marketplace or manually
-2. **Start Session** - Hook will automatically:
+1. **Start Session** - Hook will automatically:
    - Detect installed Blender versions (4.0+)
    - Create project configuration (port 9400-9500)
    - Copy and build local TypeScript scripts
    - Attempt background addon installation
-3. **Check Status** - Review installation logs:
+2. **Check Status** - Review installation logs:
    ```bash
    cat .blender-toolkit/init-log.txt
    ```

--- a/plugins/browser-pilot/README.md
+++ b/plugins/browser-pilot/README.md
@@ -75,21 +75,28 @@ Claude handles all the command execution through the SKILL.md interface - you ju
 
 ## Installation
 
+### Install Plugin
+
+```bash
+# Add marketplace
+/plugin marketplace add https://github.com/Dev-GOM/claude-code-marketplace.git
+
+# Install plugin
+/plugin install browser-pilot@dev-gom-plugins
+```
+
+**Or install directly**:
+```bash
+/plugin add https://github.com/Dev-GOM/claude-code-marketplace/tree/main/plugins/browser-pilot
+```
+
+The plugin will auto-initialize when you start a Claude Code session (via SessionStart hook).
+
 ### Prerequisites
 
 1. **Google Chrome** (latest version recommended)
 2. **Node.js** 18+ ([nodejs.org](https://nodejs.org))
 3. **Git Bash** (Windows) or Terminal (macOS/Linux)
-
-### Quick Installation
-
-```bash
-cd plugins/browser-pilot/skills/scripts
-npm install
-npm run build
-```
-
-The plugin will auto-initialize when you start a Claude Code session (via SessionStart hook).
 
 ## Quick Start
 

--- a/plugins/unity-editor-toolkit/README.ko.md
+++ b/plugins/unity-editor-toolkit/README.ko.md
@@ -44,38 +44,22 @@ Claude Code를 위한 완벽한 Unity Editor 제어 및 자동화 툴킷. 25개 
 
 이 플러그인은 [Dev GOM Plugins](https://github.com/Dev-GOM/claude-code-marketplace) 마켓플레이스의 일부입니다.
 
-### 마켓플레이스에서 설치
+### 마켓플레이스에서 설치 (권장)
 
-Claude Code 설정에 마켓플레이스를 추가하세요:
+```bash
+# 마켓플레이스 추가
+/plugin marketplace add https://github.com/Dev-GOM/claude-code-marketplace.git
 
-```json
-{
-  "plugins": {
-    "marketplaces": [
-      {
-        "name": "dev-gom-plugins",
-        "url": "https://github.com/Dev-GOM/claude-code-marketplace"
-      }
-    ]
-  }
-}
+# 플러그인 설치
+/plugin install unity-editor-toolkit@dev-gom-plugins
 ```
 
-그런 다음 플러그인을 활성화하세요:
+### 직접 설치
 
-```json
-{
-  "plugins": {
-    "enabled": ["dev-gom-plugins:unity-editor-toolkit"]
-  }
-}
+```bash
+# 저장소에서 직접 설치
+/plugin add https://github.com/Dev-GOM/claude-code-marketplace/tree/main/plugins/unity-editor-toolkit
 ```
-
-### 수동 설치
-
-1. 이 저장소를 클론합니다
-2. `plugins/unity-editor-toolkit`을 Claude Code 플러그인 디렉토리에 복사합니다
-3. Claude Code를 재시작합니다
 
 ## 사용법
 

--- a/plugins/unity-editor-toolkit/README.md
+++ b/plugins/unity-editor-toolkit/README.md
@@ -44,38 +44,22 @@ See [CHANGELOG.md](./CHANGELOG.md) for full release notes.
 
 This plugin is part of the [Dev GOM Plugins](https://github.com/Dev-GOM/claude-code-marketplace) marketplace.
 
-### Install from Marketplace
+### Install from Marketplace (Recommended)
 
-Add the marketplace to your Claude Code settings:
+```bash
+# Add marketplace
+/plugin marketplace add https://github.com/Dev-GOM/claude-code-marketplace.git
 
-```json
-{
-  "plugins": {
-    "marketplaces": [
-      {
-        "name": "dev-gom-plugins",
-        "url": "https://github.com/Dev-GOM/claude-code-marketplace"
-      }
-    ]
-  }
-}
+# Install plugin
+/plugin install unity-editor-toolkit@dev-gom-plugins
 ```
 
-Then enable the plugin:
+### Direct Installation
 
-```json
-{
-  "plugins": {
-    "enabled": ["dev-gom-plugins:unity-editor-toolkit"]
-  }
-}
+```bash
+# Install directly from repository
+/plugin add https://github.com/Dev-GOM/claude-code-marketplace/tree/main/plugins/unity-editor-toolkit
 ```
-
-### Manual Installation
-
-1. Clone this repository
-2. Copy `plugins/unity-editor-toolkit` to your Claude Code plugins directory
-3. Restart Claude Code
 
 ## Usage
 


### PR DESCRIPTION
## Summary

Corrected plugin installation instructions across all main plugins to use proper CLI commands instead of JSON configuration.

### 🔧 Fixed Plugins

1. **Unity Editor Toolkit** (README.md, README.ko.md)
2. **Blender Toolkit** (README.md)
3. **Browser Pilot** (README.md)

### ❌ Old (Incorrect) Method

```json
{
  "plugins": {
    "marketplaces": [
      {
        "name": "dev-gom-plugins",
        "url": "https://github.com/Dev-GOM/claude-code-marketplace"
      }
    ],
    "enabled": ["dev-gom-plugins:plugin-name"]
  }
}
```

### ✅ New (Correct) Method

```bash
# Add marketplace
/plugin marketplace add https://github.com/Dev-GOM/claude-code-marketplace.git

# Install plugin
/plugin install plugin-name@dev-gom-plugins
```

**Or install directly:**
```bash
/plugin add https://github.com/Dev-GOM/claude-code-marketplace/tree/main/plugins/plugin-name
```

### 📝 Changes

- Updated installation instructions to match auto-release-manager's correct approach
- Simplified installation process for users
- Consistent installation method across all plugins
- Added direct installation option

### 🎯 Benefits

- **Easier to use**: Single command instead of JSON editing
- **Less error-prone**: No risk of JSON syntax errors
- **Official method**: Matches Claude Code's official plugin installation approach
- **Consistent**: All plugins now use the same installation method

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)