### PR TITLE
feat: 첫 설치 시 Server Window 자동 열기 및 UX 개선

### DIFF
--- a/plugins/unity-editor-toolkit/skills/assets/unity-package/Editor/EditorServerWindow.cs
+++ b/plugins/unity-editor-toolkit/skills/assets/unity-package/Editor/EditorServerWindow.cs
@@ -37,7 +37,7 @@ namespace UnityEditorToolkit.Editor
         private bool hasNodeJS = false;
         private string pluginScriptsPathOverride = null;
 
-        [MenuItem("Window/Unity Editor Toolkit/Server Control")]
+        [MenuItem("Tools/Unity Editor Toolkit/Server Window")]
         public static void ShowWindow()
         {
             var window = GetWindow<EditorServerWindow>("Editor Server");

--- a/plugins/unity-editor-toolkit/skills/assets/unity-package/Editor/PackageInitializer.cs
+++ b/plugins/unity-editor-toolkit/skills/assets/unity-package/Editor/PackageInitializer.cs
@@ -1,0 +1,92 @@
+using UnityEditor;
+using UnityEngine;
+
+namespace UnityEditorToolkit.Editor
+{
+    /// <summary>
+    /// Automatically opens Server Window when package is first installed
+    /// </summary>
+    [InitializeOnLoad]
+    public static class PackageInitializer
+    {
+        private const string PACKAGE_VERSION = "0.4.0";
+        private static readonly string InitializationFilePath = Path.Combine(
+            Path.GetDirectoryName(Application.dataPath),
+            "ProjectSettings",
+            "UnityEditorToolkit.initialized"
+        );
+
+        static PackageInitializer()
+        {
+            EditorApplication.delayCall += Initialize;
+        }
+
+        private static void Initialize()
+        {
+            // Check if initialization file exists in project settings
+            bool isFirstInstall = !File.Exists(InitializationFilePath);
+            string installedVersion = "";
+
+            if (!isFirstInstall && File.Exists(InitializationFilePath))
+            {
+                try
+                {
+                    installedVersion = File.ReadAllText(InitializationFilePath).Trim();
+                }
+                catch
+                {
+                    installedVersion = "";
+                }
+            }
+
+            bool isVersionUpgrade = !string.IsNullOrEmpty(installedVersion) && installedVersion != PACKAGE_VERSION;
+
+            if (isFirstInstall)
+            {
+                // First time installation - open server window
+                try
+                {
+                    File.WriteAllText(InitializationFilePath, PACKAGE_VERSION);
+                }
+                catch (System.Exception e)
+                {
+                    Debug.LogWarning($"[Unity Editor Toolkit] Failed to create initialization file: {e.Message}");
+                }
+
+                // Delay to ensure Unity is fully loaded
+                EditorApplication.delayCall += () =>
+                {
+                    EditorWindow.GetWindow<EditorServerWindow>("Unity Editor Toolkit");
+                    Debug.Log("[Unity Editor Toolkit] Welcome! Server Window opened. Configure your plugin scripts path and install CLI to get started.");
+                };
+            }
+            else if (isVersionUpgrade)
+            {
+                // Version upgrade - just update version number
+                try
+                {
+                    File.WriteAllText(InitializationFilePath, PACKAGE_VERSION);
+                }
+                catch (System.Exception e)
+                {
+                    Debug.LogWarning($"[Unity Editor Toolkit] Failed to update version file: {e.Message}");
+                }
+                Debug.Log($"[Unity Editor Toolkit] Updated to version {PACKAGE_VERSION}");
+            }
+        }
+
+        [MenuItem("Tools/Unity Editor Toolkit/Reset Package Initialization", priority = 101)]
+        private static void ResetInitialization()
+        {
+            if (File.Exists(InitializationFilePath))
+            {
+                File.Delete(InitializationFilePath);
+                Debug.Log("[Unity Editor Toolkit] Package initialization reset. Restart Unity to trigger first-install behavior.");
+            }
+            else
+            {
+                Debug.Log("[Unity Editor Toolkit] No initialization file found - already in fresh state.");
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 변경 사항

### ✨ 새로운 기능: 자동 Server Window 열기

**PackageInitializer 추가:**
- 패키지 첫 설치 시 Server Window 자동 열기
- 환영 메시지 출력으로 사용자 가이드
- 프로젝트별 설정 파일 사용 (`ProjectSettings/UnityEditorToolkit.initialized`)
- 재설치 감지 지원 (완전 삭제 후 재설치 시 자동 열림)
- 버전 업그레이드 자동 감지 및 로깅

### 🎯 메뉴 위치 통일

**EditorServerWindow 메뉴 경로 변경:**
- Before: `Window/Unity Editor Toolkit/Server Control`
- After: `Tools/Unity Editor Toolkit/Server Window`
- 모든 문서와 일치하도록 통일

**새 메뉴 추가:**
- `Tools/Unity Editor Toolkit/Reset Package Initialization`
- 초기화 상태 리셋 가능 (테스트 및 문제 해결용)

## 사용자 경험 개선

### 첫 설치 시
1. Unity Package Manager에서 Git URL로 설치
2. Unity 재시작
3. **Server Window 자동 열림** ✨
4. 환영 메시지:
   ```
   [Unity Editor Toolkit] Welcome! Server Window opened.
   Configure your plugin scripts path and install CLI to get started.
   ```

### 이후 사용
- Unity 재시작 시 창 열리지 않음 (한 번만)
- 수동 열기: `Tools → Unity Editor Toolkit → Server Window`

### 재설치
- 패키지 삭제 후 재설치 시
- `ProjectSettings/UnityEditorToolkit.initialized` 파일도 삭제하면
- 첫 설치처럼 동작 (자동으로 창 열림)

## 기술 상세

### InitializeOnLoad
```csharp
[InitializeOnLoad]
public static class PackageInitializer
{
    static PackageInitializer()
    {
        EditorApplication.delayCall += Initialize;
    }
}
```

### 프로젝트별 설정 파일
```
ProjectSettings/UnityEditorToolkit.initialized
```
- EditorPrefs 대신 프로젝트 파일 사용
- 재설치 감지 가능
- Git ignore 대상 (프로젝트별 상태)

## Breaking Changes

없음 - 기존 기능에 영향 없음

## 테스트 체크리스트

- [ ] 첫 설치 시 Server Window 자동 열림
- [ ] Unity 재시작 시 창 열리지 않음
- [ ] 메뉴 위치 변경 확인 (Tools 아래)
- [ ] Reset 메뉴 동작 확인
- [ ] 버전 업그레이드 시 로그 출력

🤖 Generated with [Claude Code](https://claude.com/claude-code)