### PR TITLE
fix: PackageInitializer.cs 메타파일 추가

### DIFF
--- a/plugins/unity-editor-toolkit/skills/assets/unity-package/Editor/PackageInitializer.cs.meta
+++ b/plugins/unity-editor-toolkit/skills/assets/unity-package/Editor/PackageInitializer.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 9c2feb2ffa2cb9349bf55397f8521013


### PR DESCRIPTION
## 변경 사항

Unity에서 생성된 PackageInitializer.cs.meta 파일 추가

### 문제
- PackageInitializer.cs는 새로 생성된 파일이었지만
- Unity 메타파일이 Git에 포함되지 않았음
- Git URL로 패키지 설치 시 메타파일 누락 경고 발생 가능

### 해결
- Unity 프로젝트에서 자동 생성된 .meta 파일 추가
- 이제 모든 파일에 메타파일 존재

## 파일
- `Editor/PackageInitializer.cs.meta`

🤖 Generated with [Claude Code](https://claude.com/claude-code)