### PR TITLE
Add Hermes Tweet plugin guide

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -304,6 +304,27 @@
         "experimental",
         "skills"
       ]
+    },
+    {
+      "name": "hermes-tweet",
+      "source": "./plugins/hermes-tweet",
+      "description": "Native Hermes Agent X/Twitter plugin guide for read-first social workflows and approval-gated actions through Xquik",
+      "version": "0.1.6",
+      "author": {
+        "name": "Xquik"
+      },
+      "category": "productivity",
+      "homepage": "https://github.com/Xquik-dev/hermes-tweet",
+      "keywords": [
+        "hermes-agent",
+        "hermes-plugin",
+        "xquik",
+        "twitter",
+        "x",
+        "social-media",
+        "automation",
+        "skills"
+      ]
     }
   ],
   "version": "2.31.0"

--- a/README.ko.md
+++ b/README.ko.md
@@ -216,6 +216,21 @@ Claude Code를 위한 Chrome DevTools Protocol (CDP) 기반 브라우저 자동�
 
 </details>
 
+---
+
+### 15. 🐦 [Hermes Tweet](plugins/hermes-tweet/README.ko.md)
+
+<details>
+<summary><strong>📖 플러그인 상세</strong> (펼치기)</summary>
+
+Xquik을 통해 읽기 우선 소셜 워크플로우와 승인 기반 액션을 제공하는 네이티브 Hermes Agent X/Twitter 플러그인 안내입니다.
+
+**요약:** Hermes Agent에 Hermes Tweet 설치 | 읽기와 액션 분리 | `tweet_explore`, `tweet_read`, 제한된 `tweet_action` 사용 | **Skill:** Hermes Tweet 설치 및 운영 안내
+
+**[전체 문서 보기 →](plugins/hermes-tweet/README.ko.md)**
+
+</details>
+
 ## 설치
 
 ### 빠른 시작 (권장)
@@ -265,6 +280,9 @@ Claude Code를 위한 Chrome DevTools Protocol (CDP) 기반 브라우저 자동�
    ```bash
    /plugin install unity-editor-toolkit@dev-gom-plugins
    ```
+   ```bash
+   /plugin install hermes-tweet@dev-gom-plugins
+   ```
 
 3. 플러그인을 로드하기 위해 Claude Code 재시작:
    ```bash
@@ -303,6 +321,7 @@ Claude Code를 위한 Chrome DevTools Protocol (CDP) 기반 브라우저 자동�
 - **Unity Dev Toolkit**: `/unity:*` 커맨드 사용, `@unity-*`로 전문 에이전트 호출, Agent Skills를 통한 자동 스크립트 검증
 - **Claude Dev Helper**: Git diff 자동 리뷰, 변경사항 스테이징, 피드백 수집; VS Code Extension 통합으로 향상된 기능
 - **Auto Release Manager**: Claude에게 "버전 업데이트" 또는 "릴리즈 생성" 요청으로 자동 버전 관리 및 릴리즈 워크플로우
+- **Hermes Tweet**: 읽기 우선 X/Twitter 워크플로우와 명시적으로 제한된 계정 액션을 위한 Hermes Agent 설정 안내
 
 ## 설정
 

--- a/README.md
+++ b/README.md
@@ -231,6 +231,21 @@ Chrome DevTools Protocol (CDP) based browser automation, web scraping, and crawl
 
 </details>
 
+---
+
+### 16. 🐦 [Hermes Tweet](plugins/hermes-tweet/README.md)
+
+<details>
+<summary><strong>📖 Plugin Details</strong> (Click to expand)</summary>
+
+Native Hermes Agent X/Twitter plugin guide for read-first social workflows and approval-gated actions through Xquik.
+
+**Quick Info:** Installs Hermes Tweet into Hermes Agent | Keeps reads and actions separated | Uses `tweet_explore`, `tweet_read`, and gated `tweet_action` | **Skill:** Hermes Tweet install and operation guidance
+
+**[Read Full Documentation →](plugins/hermes-tweet/README.md)**
+
+</details>
+
 ## Installation
 
 ### Quick Start (Recommended)
@@ -280,6 +295,9 @@ Chrome DevTools Protocol (CDP) based browser automation, web scraping, and crawl
    ```bash
    /plugin install unity-editor-toolkit@dev-gom-plugins
    ```
+   ```bash
+   /plugin install hermes-tweet@dev-gom-plugins
+   ```
 
 3. Restart Claude Code to load the plugins:
    ```bash
@@ -318,6 +336,7 @@ Once installed, the plugins work automatically:
 - **Unity Dev Toolkit**: Use `/unity:*` commands, invoke expert agents with `@unity-*`, and get automatic script validation through Agent Skills
 - **Claude Dev Helper**: Automatically reviews git diffs, stages changes, and collects feedback; enhanced with VS Code Extension integration
 - **Auto Release Manager**: Ask Claude to "update version" or "create release" for automated version management and release workflow
+- **Hermes Tweet**: Guides Hermes Agent setup for read-first X/Twitter workflows and explicitly gated account actions
 
 ## Configuration
 

--- a/plugins/hermes-tweet/.claude-plugin/plugin.json
+++ b/plugins/hermes-tweet/.claude-plugin/plugin.json
@@ -1,0 +1,22 @@
+{
+  "name": "hermes-tweet",
+  "version": "0.1.6",
+  "description": "Native Hermes Agent X/Twitter plugin guide for read-first social workflows and approval-gated actions through Xquik.",
+  "author": {
+    "name": "Xquik",
+    "url": "https://github.com/Xquik-dev"
+  },
+  "homepage": "https://github.com/Xquik-dev/hermes-tweet",
+  "keywords": [
+    "hermes-agent",
+    "hermes-plugin",
+    "xquik",
+    "twitter",
+    "x",
+    "social-media",
+    "automation"
+  ],
+  "skills": [
+    "./skills"
+  ]
+}

--- a/plugins/hermes-tweet/README.ko.md
+++ b/plugins/hermes-tweet/README.ko.md
@@ -4,7 +4,7 @@ Xquik을 통해 X/Twitter 워크플로우를 제공하는 네이티브 Hermes Ag
 
 ## 개요
 
-Hermes Tweet는 Claude Code 사용자가 [Xquik-dev/hermes-tweet](https://github.com/Xquik-dev/hermes-tweet) 업스트림 Hermes Agent 플러그인을 설치하고 설정하며 운영하도록 돕습니다. 읽기 우선 소셜 워크플로우, 카탈로그 탐색, 계정 읽기, 트렌드, 모니터, 미디어, 추첨, 승인 기반 액션에 초점을 맞춥니다.
+Hermes Tweet은 Claude Code 사용자가 [Xquik-dev/hermes-tweet](https://github.com/Xquik-dev/hermes-tweet) 업스트림 Hermes Agent 플러그인을 설치하고 설정하며 운영하도록 돕습니다. 읽기 우선 소셜 워크플로우, 카탈로그 탐색, 계정 읽기, 트렌드, 모니터, 미디어, 추첨, 승인 기반 액션에 초점을 맞춥니다.
 
 이 마켓플레이스 항목은 Claude Code Skill 래퍼입니다. Hermes 런타임 플러그인은 업스트림 Python 패키지와 Hermes 플러그인에 남아 있습니다.
 

--- a/plugins/hermes-tweet/README.ko.md
+++ b/plugins/hermes-tweet/README.ko.md
@@ -1,0 +1,46 @@
+# Hermes Tweet
+
+Xquik을 통해 X/Twitter 워크플로우를 제공하는 네이티브 Hermes Agent 플러그인입니다.
+
+## 개요
+
+Hermes Tweet는 Claude Code 사용자가 [Xquik-dev/hermes-tweet](https://github.com/Xquik-dev/hermes-tweet) 업스트림 Hermes Agent 플러그인을 설치하고 설정하며 운영하도록 돕습니다. 읽기 우선 소셜 워크플로우, 카탈로그 탐색, 계정 읽기, 트렌드, 모니터, 미디어, 추첨, 승인 기반 액션에 초점을 맞춥니다.
+
+이 마켓플레이스 항목은 Claude Code Skill 래퍼입니다. Hermes 런타임 플러그인은 업스트림 Python 패키지와 Hermes 플러그인에 남아 있습니다.
+
+## 설치
+
+마켓플레이스에서 이 Claude Code 플러그인을 설치합니다:
+
+```bash
+/plugin marketplace add https://github.com/Dev-GOM/claude-code-marketplace.git
+/plugin install hermes-tweet@dev-gom-plugins
+```
+
+그 다음 Hermes Agent 플러그인을 설치합니다:
+
+```bash
+hermes plugins install Xquik-dev/hermes-tweet --enable
+```
+
+Hermes는 대화형 설치 중 `XQUIK_API_KEY`를 요청합니다. 비대화형 설정에서는 `tweet_read` 호출 전에 Hermes 런타임 환경에 키를 설정하세요.
+
+```bash
+export XQUIK_API_KEY="xq_..."
+export HERMES_TWEET_ENABLE_ACTIONS="false"
+```
+
+게시, 답글, 좋아요, 리트윗, 팔로우, DM, 미디어 변경, 웹훅, 모니터가 필요한 세션이 아니라면 `HERMES_TWEET_ENABLE_ACTIONS=false`를 유지하세요.
+
+## 사용법
+
+- 먼저 `tweet_explore`로 지원되는 `/api/v1/...` 경로를 찾습니다.
+- 카탈로그에 있는 읽기 전용 요청에는 `tweet_read`를 사용합니다.
+- 계정 변경 작업이 필요한 세션에서만 `tweet_action`을 활성화합니다.
+- API 키를 채팅에 붙여넣지 마세요. Hermes 런타임 환경에서 secret을 설정하세요.
+
+## 링크
+
+- [Hermes Tweet README](https://github.com/Xquik-dev/hermes-tweet#readme)
+- [PyPI 패키지](https://pypi.org/project/hermes-tweet/)
+- [Hermes Agent](https://github.com/NousResearch/hermes-agent)

--- a/plugins/hermes-tweet/README.md
+++ b/plugins/hermes-tweet/README.md
@@ -1,0 +1,46 @@
+# Hermes Tweet
+
+Native Hermes Agent plugin for X/Twitter workflows through Xquik.
+
+## Overview
+
+Hermes Tweet helps Claude Code users install, configure, and operate the upstream Hermes Agent plugin from [Xquik-dev/hermes-tweet](https://github.com/Xquik-dev/hermes-tweet). It focuses on read-first social workflows, catalog discovery, account reads, trends, monitors, media, draws, and approval-gated actions.
+
+This marketplace entry is a Claude Code skill wrapper. The Hermes runtime plugin remains the upstream Python package and Hermes plugin.
+
+## Install
+
+Install this Claude Code plugin from the marketplace:
+
+```bash
+/plugin marketplace add https://github.com/Dev-GOM/claude-code-marketplace.git
+/plugin install hermes-tweet@dev-gom-plugins
+```
+
+Then install the Hermes Agent plugin:
+
+```bash
+hermes plugins install Xquik-dev/hermes-tweet --enable
+```
+
+Hermes prompts for `XQUIK_API_KEY` during interactive install. For non-interactive setups, set it in the Hermes runtime environment before calling `tweet_read`.
+
+```bash
+export XQUIK_API_KEY="xq_..."
+export HERMES_TWEET_ENABLE_ACTIONS="false"
+```
+
+Keep `HERMES_TWEET_ENABLE_ACTIONS=false` unless the session explicitly needs posting, replies, likes, retweets, follows, DMs, media changes, webhooks, or monitors.
+
+## Usage
+
+- Use `tweet_explore` first to find supported `/api/v1/...` routes.
+- Use `tweet_read` for catalog-listed read-only requests.
+- Enable `tweet_action` only for sessions that require account-changing operations.
+- Do not paste API keys into chat. Configure secrets through the Hermes runtime environment.
+
+## Links
+
+- [Hermes Tweet README](https://github.com/Xquik-dev/hermes-tweet#readme)
+- [PyPI package](https://pypi.org/project/hermes-tweet/)
+- [Hermes Agent](https://github.com/NousResearch/hermes-agent)

--- a/plugins/hermes-tweet/skills/SKILL.md
+++ b/plugins/hermes-tweet/skills/SKILL.md
@@ -34,7 +34,7 @@ hermes plugins list
 For a published-package install into the Hermes Python environment:
 
 ```bash
-uv pip install --python ~/.hermes/hermes-agent/venv/bin/python hermes-tweet
+~/.hermes/hermes-agent/venv/bin/python -m pip install hermes-tweet
 hermes plugins enable hermes-tweet
 ```
 

--- a/plugins/hermes-tweet/skills/SKILL.md
+++ b/plugins/hermes-tweet/skills/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: hermes-tweet
+description: Install, configure, and operate Hermes Tweet, the native Hermes Agent X/Twitter plugin for read-first social workflows and approval-gated actions.
+allowed-tools: Bash, Read
+---
+
+# Hermes Tweet
+
+Use this skill when a user wants Hermes Agent to search X/Twitter, inspect account or trend data, monitor social signals, or prepare approval-gated account actions through Hermes Tweet.
+
+## Safety Rules
+
+- Keep API keys out of chat, prompts, docs, issue text, and command output.
+- Configure `XQUIK_API_KEY` in the Hermes runtime environment or `~/.hermes/.env`.
+- Keep `HERMES_TWEET_ENABLE_ACTIONS=false` unless the operator explicitly asks for posting, replies, likes, retweets, follows, DMs, media changes, webhooks, or monitors.
+- Use `tweet_explore` before `tweet_read` or `tweet_action`.
+- Treat copied endpoint URLs as route hints only. Call only catalog-listed `/api/v1/...` paths.
+
+## Install
+
+Recommended Hermes Agent install:
+
+```bash
+hermes plugins install Xquik-dev/hermes-tweet --enable
+```
+
+If Hermes cannot enable the plugin during install, enable it explicitly:
+
+```bash
+hermes plugins enable hermes-tweet
+hermes plugins list
+```
+
+For a published-package install into the Hermes Python environment:
+
+```bash
+uv pip install --python ~/.hermes/hermes-agent/venv/bin/python hermes-tweet
+hermes plugins enable hermes-tweet
+```
+
+For local development from a trusted checkout:
+
+```bash
+hermes plugins install file:///absolute/path/to/hermes-tweet --force --enable
+```
+
+## Configure
+
+Set the read key before calling `tweet_read`:
+
+```bash
+export XQUIK_API_KEY="xq_..."
+export HERMES_TWEET_ENABLE_ACTIONS="false"
+```
+
+If you edit `~/.hermes/.env` during an active Hermes session, use `/reload` in the interactive CLI or restart gateway and cron sessions.
+
+## Tool Flow
+
+1. Call `tweet_explore` with the workflow goal.
+2. Choose a catalog-listed read route.
+3. Call `tweet_read` with the concrete `/api/v1/...` path and required parameters.
+4. Ask for explicit operator approval before enabling or calling `tweet_action`.
+
+## References
+
+- Hermes Tweet: https://github.com/Xquik-dev/hermes-tweet
+- PyPI: https://pypi.org/project/hermes-tweet/
+- Hermes Agent: https://github.com/NousResearch/hermes-agent


### PR DESCRIPTION
## Summary
- Add Hermes Tweet as a skill-backed marketplace plugin entry.
- Add English and Korean docs for installing the upstream Hermes Agent plugin.
- Keep X/Twitter reads first and account-changing actions explicitly gated.

## Review Notes
- Target repo is public, non-archived, and Apache-2.0 licensed.
- Upstream Hermes Tweet is MIT licensed and published at https://github.com/Xquik-dev/hermes-tweet.
- Duplicate PR searches for "Hermes Tweet", `hermes-tweet`, and `Xquik` returned 0 results in this repository before opening this PR.

## Validation
- `jq empty .claude-plugin/marketplace.json plugins/hermes-tweet/.claude-plugin/plugin.json`
- `git diff --check`
- Verified every marketplace `source` path has a plugin manifest.
